### PR TITLE
feat: Add bi-allele frequency track and related code

### DIFF
--- a/src/data/samples.ts
+++ b/src/data/samples.ts
@@ -29,6 +29,7 @@ export type SampleType = {
     vcf2?: string;
     vcf2Index?: string;
     cnFields?: [string, string, string];
+    baf?: string,
     thumbnail?: string;
     note?: string;
 };

--- a/src/mid-spec.ts
+++ b/src/mid-spec.ts
@@ -14,6 +14,7 @@ export default function getMidView(option: SpecOption): View[] {
         vcf2Index,
         cnv,
         sv,
+        baf,
         width,
         showPutativeDriver,
         showOverview,
@@ -131,6 +132,11 @@ export default function getMidView(option: SpecOption): View[] {
                     width,
                     height: 60
                 },
+                ...(! baf
+                    ? []
+                    : [
+                        tracks.biAlleleFrequency(id, baf, width, 120, 'mid')
+                    ]),
                 ...(!vcf
                     ? []
                     : [tracks.mutation(id, vcf, vcfIndex, width, 60, 'mid'), tracks.boundary('mutation', 'mid')]),

--- a/src/track/bi-allele-frequency.ts
+++ b/src/track/bi-allele-frequency.ts
@@ -1,0 +1,56 @@
+import { OverlaidTracks } from 'gosling.js/dist/src/core/gosling.schema';
+import { TrackMode } from './index';
+
+export default function biAlleleFrequency(
+    sampleId: string,
+    url: string,
+    width: number,
+    height: number,
+    mode: TrackMode,
+): OverlaidTracks {
+    return {
+        id: `${sampleId}-${mode}-bi-allele-frequency`,
+        title: mode === 'small' ? '' : 'Bi Allele Frequency',
+        style: { background: '#FFFFFF' },
+        data: {
+            type: "beddb",
+            url: url,
+            genomicFields: [
+                {index: 1, name: "start"},
+                {index: 2, name: "end"}
+            ],	
+            valueFields: [
+                {index: 0, name: "chr", type: "nominal"},
+                {index: 3, name: "baf", type: "quantitative"},
+                {index: 4, name: "priority", type: "quantitative"},
+            ]
+        },
+        mark: "point",
+        x: { field: 'start', type: 'genomic' },
+        alignment: 'overlay',
+        tracks: [
+        {
+            y:{
+                field: "baf",
+                type: "quantitative",
+                axis: 'right', 
+                grid: true, 
+                domain: [-10,110],
+            },
+        },
+        ],
+        tooltip: [
+            { field: "baf", type: 'quantitative' },
+            { field: "chr", type: 'quantitative' },
+            { field: "start", type: 'quantitative' },
+            { field: "end", type: 'quantitative' },
+        ],
+        size: { value: 1 },
+        stroke: { value: '#808080' },
+        color: { value: '#808080' },
+        strokeWidth: { value: 1 },
+        opacity: { value: 0.7 },
+        width,
+        height,
+    };
+}

--- a/src/track/index.ts
+++ b/src/track/index.ts
@@ -7,6 +7,7 @@ import sv from './sv';
 import mutation from './mutation';
 import indel from './indel';
 import boundary from './boundary';
+import biAlleleFrequency from './bi-allele-frequency';
 
 export type TrackMode = 'small' | 'top' | 'mid';
 
@@ -19,5 +20,6 @@ export default {
     sv,
     mutation,
     indel,
-    boundary
+    boundary,
+    biAlleleFrequency,
 };


### PR DESCRIPTION
This commit introduces the following changes:

1. In `samples.ts`:
   - Added a new field `baf` to the `SampleType` interface.

2. In `mid-spec.ts`:
   - Modified the `getMidView` function to include the bi-allele frequency track.
   - If `baf` is provided, it adds the `biAlleleFrequency` track to the visualization.

3. In `track/index.ts`:
   - Imported and included the `biAlleleFrequency` track.

4. Added a new file `bi-allele-frequency.ts`:
   - Defines the `biAlleleFrequency` function that generates the bi-allele frequency track.

The bi-allele frequency track displays genomic data related to bi-allelic variants. It includes points representing the bi-allele frequency at specific genomic positions.